### PR TITLE
Add compression implementation to proxies

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -4,3 +4,8 @@ mod scheme;
 
 pub type Compressor<W> = clients::Compressor<W>;
 pub type Decompressor<W> = clients::Decompressor<W>;
+
+/// Given a buffer of bytes, returns a Vec of slices of each compressed frame in the buffer.
+pub fn split_frames(data: &[u8]) -> Vec<&[u8]> {
+    clients::split_frames(data)
+}

--- a/src/compression/clients.rs
+++ b/src/compression/clients.rs
@@ -226,7 +226,7 @@ mod tests {
         let decompressed_result = reference_dec.get_ref();
 
         assert!(result.len() > 0);
-        assert_eq!(decompressed_result, message);
+        assert_eq!(decompressed_result.as_slice(), message);
     }
 
     #[test]
@@ -287,6 +287,6 @@ mod tests {
         let result = writer.get_ref().get_ref();
 
         assert!(result.len() > 0);
-        assert_eq!(result, message);
+        assert_eq!(result.as_slice(), message);
     }
 }

--- a/src/compression/header.rs
+++ b/src/compression/header.rs
@@ -12,7 +12,7 @@ pub struct Header {
 
 // TODO: what should the magic value be? How many bytes should it be?
 /// Magic value that indicates this is the start of a compression Header record
-const HEADER_MAGIC_VALUE: u16 = 0xbeef;
+pub const HEADER_MAGIC_VALUE: u16 = 0xbeef;
 
 impl Header {
     pub fn new(scheme: Scheme) -> Header {

--- a/src/forward_proxy.rs
+++ b/src/forward_proxy.rs
@@ -16,7 +16,7 @@ pub fn run(local_addr: SocketAddr, compress: bool, encrypt: bool) -> Result<()> 
     rt.block_on(run_async(local_addr, compress, encrypt))
 }
 
-pub async fn run_async (local_addr: SocketAddr, compress: bool, encrypt: bool) -> Result<()> {
+pub async fn run_async(local_addr: SocketAddr, compress: bool, encrypt: bool) -> Result<()> {
     println!("opening listener socket on {}", local_addr);
     let listen_socket = TcpListener::bind(local_addr)
         .await
@@ -34,7 +34,11 @@ pub async fn run_async (local_addr: SocketAddr, compress: bool, encrypt: bool) -
 /// Note: this function allows for a custom TcpListener to be provided. Most users will either want
 /// to call run() or run_async() which sets the IP_TRANSPARENT option for the socket. This function
 /// is primarily useful for testing without the IP_TRANSPARENT option.
-pub async fn forward_proxy(listen_socket: TcpListener, compress: bool, encrypt: bool) -> Result<()> {
+pub async fn forward_proxy(
+    listen_socket: TcpListener,
+    compress: bool,
+    encrypt: bool,
+) -> Result<()> {
     loop {
         let (from_conn, from_addr) = listen_socket
             .accept()
@@ -46,8 +50,7 @@ pub async fn forward_proxy(listen_socket: TcpListener, compress: bool, encrypt: 
             Ok(socket::SockAddr::Inet(inet_addr)) => {
                 println!("connection destined to {}", inet_addr);
 
-                let to_addr =
-                    SocketAddr::new(inet_addr.ip().to_std(), reverse_proxy::HTTPS_PORT);
+                let to_addr = SocketAddr::new(inet_addr.ip().to_std(), reverse_proxy::HTTPS_PORT);
 
                 if let Ok(to_conn) = TcpStream::connect(to_addr).await {
                     println!("connection opened to {}", to_addr);

--- a/src/forward_proxy.rs
+++ b/src/forward_proxy.rs
@@ -133,7 +133,7 @@ async fn proxy_conn(
 
 #[cfg(test)]
 mod tests {
-    use crate::compression::Compressor;
+    use crate::compression::{split_frames, Compressor, Decompressor};
     use crate::forward_proxy::proxy_conn;
     use std::io::Write;
     use tokio;
@@ -205,5 +205,42 @@ mod tests {
         ref_compressor.write_all(&message).unwrap();
 
         assert_eq!(received, ref_compressor.finish().unwrap());
+    }
+
+    #[tokio::test]
+    async fn proxy_large_compressed_content() {
+        // ~2kB message
+        let message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam risus metus, vulputate sed erat non, maximus accumsan augue. Ut eu aliquet urna, sed mollis lectus. Vivamus eu egestas lectus. Donec commodo diam vehicula nisl iaculis, at scelerisque est efficitur. Pellentesque sed dolor arcu. Nullam semper quam risus, quis lobortis sapien mollis vitae. Fusce egestas ante nisl, ac bibendum mi faucibus ac. Phasellus eu libero orci. Cras dignissim in nibh quis eleifend. Duis mattis fermentum nulla ac aliquet. Cras et orci quis erat fermentum auctor et in mauris. Ut ornare, elit a blandit imperdiet, nibh sapien dapibus sapien, non faucibus diam arcu fermentum nunc. Proin feugiat pharetra lectus vitae semper. Fusce sit amet tortor mattis, hendrerit ex nec, iaculis risus.
+
+Nam est nibh, semper sit amet gravida eu, efficitur in tortor. Aenean vel leo vitae enim scelerisque porta at et nibh. Nulla malesuada vel ipsum placerat varius. Aliquam facilisis, dolor quis ultrices condimentum, nisl metus consequat purus, non vulputate odio odio at justo. Fusce rhoncus neque arcu, et venenatis lacus vestibulum at. Nullam tristique tincidunt nunc. Ut mollis sem non turpis accumsan, et volutpat quam suscipit. Cras metus libero, commodo vitae purus vulputate, scelerisque molestie mi. Etiam posuere orci id turpis suscipit egestas. Nunc id faucibus risus.
+
+Duis quis neque sit amet turpis ullamcorper pretium a et turpis. In ultrices eros sit amet odio venenatis varius. Vestibulum id sem iaculis dolor ornare egestas eu sit amet nunc. Integer elit lorem, pretium vestibulum euismod in, imperdiet porttitor nisl. In accumsan elit non rutrum euismod. Integer turpis sem, lobortis non laoreet id, mattis at metus. Sed hendrerit volutpat dui ut consectetur.
+
+Duis efficitur, lacus a condimentum rhoncus, justo ex tristique neque, fermentum imperdiet tortor ex a ante. Mauris a tortor nec sapien volutpat porttitor. Praesent purus erat, viverra sed rhoncus eget, sodales ac felis. Integer scelerisque leo gravida.".as_bytes();
+        let mut received = Vec::new();
+
+        let mut test_proxy = setup_proxy(true, false).await;
+
+        test_proxy.reader.write_all(&message).await.unwrap();
+        test_proxy.reader.shutdown().await.unwrap();
+        test_proxy.writer.read_to_end(&mut received).await.unwrap();
+
+        let compression_frames = split_frames(&received);
+        // The forward proxy should receive the data as 2 different messages, each will be
+        // compressed separately.
+        // TODO: should make this more maintainable by not hardcoding it to expect 2 chunks but
+        //  rather the number of chunks that should be produced
+        assert_eq!(compression_frames.len(), 2);
+
+        let decompressed_data: Vec<u8> = compression_frames
+            .iter()
+            .flat_map(|frame| {
+                let mut ref_decompressor = Decompressor::new(Vec::new());
+                ref_decompressor.write_all(frame).unwrap();
+                ref_decompressor.finish().unwrap()
+            })
+            .collect();
+
+        assert_eq!(message, decompressed_data);
     }
 }

--- a/src/forward_proxy.rs
+++ b/src/forward_proxy.rs
@@ -44,10 +44,10 @@ pub fn run(local_addr: SocketAddr, compress: bool, encrypt: bool) -> Result<()> 
                         let (server_read, server_write) = split::<TcpStream>(to_conn);
 
                         tokio::spawn(async move {
-                            to_server(client_read, server_write, compress, encrypt).await;
+                            proxy_conn(client_read, server_write, compress, encrypt).await;
                         });
                         tokio::spawn(async move {
-                            to_client(server_read, client_write, compress, encrypt).await;
+                            proxy_conn(server_read, client_write, compress, encrypt).await;
                         });
                     } else {
                         eprintln!("failed to connect to {}", to_addr);
@@ -59,7 +59,7 @@ pub fn run(local_addr: SocketAddr, compress: bool, encrypt: bool) -> Result<()> 
     })
 }
 
-async fn to_server(
+async fn proxy_conn(
     mut read_conn: ReadHalf<TcpStream>,
     mut write_conn: WriteHalf<TcpStream>,
     _compress: bool,
@@ -68,15 +68,15 @@ async fn to_server(
     let mut buf = vec![0; 1024];
 
     loop {
-        // echo client to server
+        // proxy from the read connection to the write connection
         match read_conn.read(&mut buf).await {
             Ok(0) => {
-                println!("Client closed connection");
+                println!("Read connection closed");
                 break;
             }
             Ok(n) => {
                 if let Err(_) = write_conn.write_all(&buf[..n]).await {
-                    eprintln!("Error sending to server");
+                    eprintln!("Error sending to write connection");
                     break;
                 }
             }
@@ -90,33 +90,59 @@ async fn to_server(
     let _ = write_conn.shutdown().await;
 }
 
-async fn to_client(
-    mut read_conn: ReadHalf<TcpStream>,
-    mut write_conn: WriteHalf<TcpStream>,
-    _compress: bool,
-    _encrypt: bool,
-) {
-    let mut buf = vec![0; 1024];
+#[cfg(test)]
+mod tests {
+    use crate::forward_proxy::proxy_conn;
+    use tokio;
+    use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
 
-    loop {
-        // echo server to client
-        match read_conn.read(&mut buf).await {
-            Ok(0) => {
-                println!("Server closed connection");
-                break;
-            }
-            Ok(n) => {
-                if let Err(_) = write_conn.write_all(&buf[..n]).await {
-                    eprintln!("Error sending to client");
-                    break;
-                }
-            }
-            Err(_) => {
-                eprintln!("Socket error");
-                break;
-            }
+    struct TestProxy {
+        reader: TcpStream,
+        writer: TcpStream,
+    }
+
+    /// Helper function to create proxied tcp connections. Returns a tuple of the connections to
+    /// write to the proxy and read from the proxy respectively
+    async fn setup_proxy(compress: bool, encrypt: bool) -> TestProxy {
+        let in_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+        let out_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+        let in_send_conn = TcpStream::connect(in_listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (in_recv_conn, _) = in_listener.accept().await.unwrap();
+
+        let out_send_conn = TcpStream::connect(out_listener.local_addr().unwrap())
+            .await
+            .unwrap();
+        let (out_recv_conn, _) = out_listener.accept().await.unwrap();
+
+        let (in_recv_read, _) = split::<TcpStream>(in_recv_conn);
+        let (_, out_send_write) = split::<TcpStream>(out_send_conn);
+
+        tokio::spawn(async move {
+            proxy_conn(in_recv_read, out_send_write, compress, encrypt).await;
+        });
+
+        TestProxy {
+            reader: in_send_conn,
+            writer: out_recv_conn,
         }
     }
 
-    let _ = write_conn.shutdown().await;
+    #[tokio::test]
+    async fn proxy_content() {
+        let message = "Hello world! This is message should be proxied.".as_bytes();
+        let mut received = Vec::new();
+
+        let mut test_proxy = setup_proxy(false, false).await;
+
+        test_proxy.reader.write_all(&message).await.unwrap();
+        test_proxy.reader.shutdown().await.unwrap();
+        test_proxy.writer.read_to_end(&mut received).await.unwrap();
+
+        assert_eq!(received, message);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod compression;
+pub mod compression;
 pub mod forward_proxy;
 pub mod reverse_proxy;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+mod compression;
+pub mod forward_proxy;
+pub mod reverse_proxy;
+
+pub mod errors {
+    error_chain::error_chain! {
+        foreign_links {
+            NixError(nix::Error);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@
 //          - If data received from server, send to client using write() and then write_tls() (assuming rustls)
 //              - Optionally compress data before sending
 
-
 use error_chain::bail;
 use error_chain::ChainedError;
 use rust_tls_proxy::errors::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@
 
 mod forward_proxy;
 mod reverse_proxy;
+mod compression;
 
 use error_chain::bail;
 use error_chain::ChainedError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,9 +22,9 @@
 //          - If data received from server, send to client using write() and then write_tls() (assuming rustls)
 //              - Optionally compress data before sending
 
+mod compression;
 mod forward_proxy;
 mod reverse_proxy;
-mod compression;
 
 use error_chain::bail;
 use error_chain::ChainedError;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,20 +22,12 @@
 //          - If data received from server, send to client using write() and then write_tls() (assuming rustls)
 //              - Optionally compress data before sending
 
-mod compression;
-mod forward_proxy;
-mod reverse_proxy;
 
 use error_chain::bail;
 use error_chain::ChainedError;
-mod errors {
-    error_chain::error_chain! {
-        foreign_links {
-            NixError(nix::Error);
-        }
-    }
-}
-use errors::*;
+use rust_tls_proxy::errors::*;
+
+use rust_tls_proxy::{forward_proxy, reverse_proxy};
 
 use clap::{App, AppSettings, Arg, SubCommand};
 use std::net::{IpAddr, SocketAddr};

--- a/tests/proxy_tests.rs
+++ b/tests/proxy_tests.rs
@@ -1,12 +1,12 @@
 use tokio;
-use tokio::net::{TcpListener, TcpStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
-use rust_tls_proxy::{forward_proxy, reverse_proxy};
 use rust_tls_proxy::compression::Compressor;
+use rust_tls_proxy::{forward_proxy, reverse_proxy};
+use std::io::Write;
 use std::net::SocketAddr;
 use std::time::Duration;
-use std::io::Write;
 
 #[tokio::test]
 async fn transparent_proxy() {
@@ -21,11 +21,15 @@ async fn transparent_proxy() {
     let forward_proxy_listener = TcpListener::bind(forward_in_addr).await.unwrap();
 
     tokio::spawn(async move {
-        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], false, false).await.unwrap();
+        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], false, false)
+            .await
+            .unwrap();
     });
 
     tokio::spawn(async move {
-        forward_proxy::forward_proxy(forward_proxy_listener, false, false).await.unwrap();
+        forward_proxy::forward_proxy(forward_proxy_listener, false, false)
+            .await
+            .unwrap();
     });
 
     let mut in_send_conn = TcpStream::connect(forward_in_addr).await.unwrap();
@@ -65,11 +69,15 @@ async fn transparent_compression_proxy() {
     let forward_out_listener = TcpListener::bind(forward_out_addr).await.unwrap();
 
     tokio::spawn(async move {
-        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], true, false).await.unwrap();
+        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], true, false)
+            .await
+            .unwrap();
     });
 
     tokio::spawn(async move {
-        forward_proxy::forward_proxy(forward_proxy_listener, true, false).await.unwrap();
+        forward_proxy::forward_proxy(forward_proxy_listener, true, false)
+            .await
+            .unwrap();
     });
 
     let mut in_send_conn = TcpStream::connect(forward_in_addr).await.unwrap();
@@ -80,7 +88,10 @@ async fn transparent_compression_proxy() {
     let (mut forward_out_conn, _) = forward_out_listener.accept().await.unwrap();
     write_fut.await.unwrap();
     in_send_conn.shutdown().await.unwrap();
-    forward_out_conn.read_to_end(&mut forward_out_sent).await.unwrap();
+    forward_out_conn
+        .read_to_end(&mut forward_out_sent)
+        .await
+        .unwrap();
 
     assert_eq!(forward_out_sent, compressed_message);
 

--- a/tests/proxy_tests.rs
+++ b/tests/proxy_tests.rs
@@ -103,3 +103,76 @@ async fn transparent_compression_proxy() {
 
     assert_eq!(received, message);
 }
+
+// TODO: these tests are a bunch of hacked together lines. Should refactor out into smaller tests
+//  and helper methods.
+#[tokio::test]
+async fn transparent_compression_proxy_with_large_message() {
+    // TODO: hack to make sure previous sockets are freed up
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam risus metus, vulputate sed erat non, maximus accumsan augue. Ut eu aliquet urna, sed mollis lectus. Vivamus eu egestas lectus. Donec commodo diam vehicula nisl iaculis, at scelerisque est efficitur. Pellentesque sed dolor arcu. Nullam semper quam risus, quis lobortis sapien mollis vitae. Fusce egestas ante nisl, ac bibendum mi faucibus ac. Phasellus eu libero orci. Cras dignissim in nibh quis eleifend. Duis mattis fermentum nulla ac aliquet. Cras et orci quis erat fermentum auctor et in mauris. Ut ornare, elit a blandit imperdiet, nibh sapien dapibus sapien, non faucibus diam arcu fermentum nunc. Proin feugiat pharetra lectus vitae semper. Fusce sit amet tortor mattis, hendrerit ex nec, iaculis risus.
+
+Nam est nibh, semper sit amet gravida eu, efficitur in tortor. Aenean vel leo vitae enim scelerisque porta at et nibh. Nulla malesuada vel ipsum placerat varius. Aliquam facilisis, dolor quis ultrices condimentum, nisl metus consequat purus, non vulputate odio odio at justo. Fusce rhoncus neque arcu, et venenatis lacus vestibulum at. Nullam tristique tincidunt nunc. Ut mollis sem non turpis accumsan, et volutpat quam suscipit. Cras metus libero, commodo vitae purus vulputate, scelerisque molestie mi. Etiam posuere orci id turpis suscipit egestas. Nunc id faucibus risus.
+
+Duis quis neque sit amet turpis ullamcorper pretium a et turpis. In ultrices eros sit amet odio venenatis varius. Vestibulum id sem iaculis dolor ornare egestas eu sit amet nunc. Integer elit lorem, pretium vestibulum euismod in, imperdiet porttitor nisl. In accumsan elit non rutrum euismod. Integer turpis sem, lobortis non laoreet id, mattis at metus. Sed hendrerit volutpat dui ut consectetur.
+
+Duis efficitur, lacus a condimentum rhoncus, justo ex tristique neque, fermentum imperdiet tortor ex a ante. Mauris a tortor nec sapien volutpat porttitor. Praesent purus erat, viverra sed rhoncus eget, sodales ac felis. Integer scelerisque leo gravida.".as_bytes();
+    // Currently the forward proxy separates messages into chunks of at most 1024 bytes
+    // TODO: make this maintainable by removing hardcoded values
+    let compressed_messages = message.chunks(1024).map(|chunk| {
+        let mut ref_compressor = Compressor::new(Vec::new());
+        ref_compressor.write_all(chunk).unwrap();
+        ref_compressor.finish().unwrap()
+    });
+
+    let mut forward_out_sent = Vec::new();
+    let mut received = Vec::new();
+
+    let forward_in_addr: SocketAddr = "127.0.0.1:8123".parse().unwrap();
+    let forward_out_addr: SocketAddr = "127.0.0.1:9443".parse().unwrap();
+    let reverse_in_addr: SocketAddr = "127.0.0.1:8124".parse().unwrap();
+    let reverse_out_addr: SocketAddr = "127.0.0.1:8125".parse().unwrap();
+
+    let out_listener = TcpListener::bind(reverse_out_addr).await.unwrap();
+    let forward_proxy_listener = TcpListener::bind(forward_in_addr).await.unwrap();
+    let forward_out_listener = TcpListener::bind(forward_out_addr).await.unwrap();
+
+    tokio::spawn(async move {
+        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], true, false)
+            .await
+            .unwrap();
+    });
+
+    tokio::spawn(async move {
+        forward_proxy::forward_proxy(forward_proxy_listener, true, false)
+            .await
+            .unwrap();
+    });
+
+    let mut in_send_conn = TcpStream::connect(forward_in_addr).await.unwrap();
+
+    let write_fut = in_send_conn.write_all(&message);
+
+    // Check output from forward proxy to make sure it's compressed
+    let (mut forward_out_conn, _) = forward_out_listener.accept().await.unwrap();
+    write_fut.await.unwrap();
+    in_send_conn.shutdown().await.unwrap();
+    forward_out_conn
+        .read_to_end(&mut forward_out_sent)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        forward_out_sent,
+        compressed_messages.flatten().collect::<Vec<u8>>()
+    );
+
+    let mut reverse_in_conn = TcpStream::connect(reverse_in_addr).await.unwrap();
+    let (mut out_recv_conn, _) = out_listener.accept().await.unwrap();
+    reverse_in_conn.write_all(&forward_out_sent).await.unwrap();
+    reverse_in_conn.shutdown().await.unwrap();
+    out_recv_conn.read_to_end(&mut received).await.unwrap();
+
+    assert_eq!(received, message);
+}

--- a/tests/proxy_tests.rs
+++ b/tests/proxy_tests.rs
@@ -1,0 +1,39 @@
+use tokio;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use rust_tls_proxy::{forward_proxy, reverse_proxy};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+#[tokio::test]
+async fn transparent_proxy() {
+    let message = "Hello world! This is message should be proxied.".as_bytes();
+    let mut received = Vec::new();
+
+    let forward_in_addr: SocketAddr = "127.0.0.1:8123".parse().unwrap();
+    let reverse_in_addr: SocketAddr = "127.0.0.1:9443".parse().unwrap();
+    let reverse_out_addr: SocketAddr = "127.0.0.1:8125".parse().unwrap();
+
+    let out_listener = TcpListener::bind(reverse_out_addr).await.unwrap();
+    let forward_proxy_listener = TcpListener::bind(forward_in_addr).await.unwrap();
+
+    tokio::spawn(async move {
+        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], false, false).await.unwrap();
+    });
+
+    tokio::spawn(async move {
+        forward_proxy::forward_proxy(forward_proxy_listener, false, false).await.unwrap();
+    });
+
+    let mut in_send_conn = TcpStream::connect(forward_in_addr).await.unwrap();
+
+    in_send_conn.write_all(&message).await.unwrap();
+
+    let (mut out_recv_conn, _) = out_listener.accept().await.unwrap();
+
+    in_send_conn.shutdown().await.unwrap();
+    out_recv_conn.read_to_end(&mut received).await.unwrap();
+
+    assert_eq!(received, message);
+}

--- a/tests/proxy_tests.rs
+++ b/tests/proxy_tests.rs
@@ -3,8 +3,10 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use rust_tls_proxy::{forward_proxy, reverse_proxy};
+use rust_tls_proxy::compression::Compressor;
 use std::net::SocketAddr;
 use std::time::Duration;
+use std::io::Write;
 
 #[tokio::test]
 async fn transparent_proxy() {
@@ -33,6 +35,59 @@ async fn transparent_proxy() {
     let (mut out_recv_conn, _) = out_listener.accept().await.unwrap();
 
     in_send_conn.shutdown().await.unwrap();
+    out_recv_conn.read_to_end(&mut received).await.unwrap();
+
+    assert_eq!(received, message);
+}
+
+// TODO: these tests are a bunch of hacked together lines. Should refactor out into smaller tests
+//  and helper methods.
+#[tokio::test]
+async fn transparent_compression_proxy() {
+    // TODO: hack to make sure previous sockets are freed up
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let message = "Hello world! This is message should be proxied.".as_bytes();
+    let mut ref_compressor = Compressor::new(Vec::new());
+    ref_compressor.write_all(&message).unwrap();
+    let compressed_message = ref_compressor.finish().unwrap();
+
+    let mut forward_out_sent = Vec::new();
+    let mut received = Vec::new();
+
+    let forward_in_addr: SocketAddr = "127.0.0.1:8123".parse().unwrap();
+    let forward_out_addr: SocketAddr = "127.0.0.1:9443".parse().unwrap();
+    let reverse_in_addr: SocketAddr = "127.0.0.1:8124".parse().unwrap();
+    let reverse_out_addr: SocketAddr = "127.0.0.1:8125".parse().unwrap();
+
+    let out_listener = TcpListener::bind(reverse_out_addr).await.unwrap();
+    let forward_proxy_listener = TcpListener::bind(forward_in_addr).await.unwrap();
+    let forward_out_listener = TcpListener::bind(forward_out_addr).await.unwrap();
+
+    tokio::spawn(async move {
+        reverse_proxy::run_async(reverse_in_addr, vec![reverse_out_addr], true, false).await.unwrap();
+    });
+
+    tokio::spawn(async move {
+        forward_proxy::forward_proxy(forward_proxy_listener, true, false).await.unwrap();
+    });
+
+    let mut in_send_conn = TcpStream::connect(forward_in_addr).await.unwrap();
+
+    let write_fut = in_send_conn.write_all(&message);
+
+    // Check output from forward proxy to make sure it's compressed
+    let (mut forward_out_conn, _) = forward_out_listener.accept().await.unwrap();
+    write_fut.await.unwrap();
+    in_send_conn.shutdown().await.unwrap();
+    forward_out_conn.read_to_end(&mut forward_out_sent).await.unwrap();
+
+    assert_eq!(forward_out_sent, compressed_message);
+
+    let mut reverse_in_conn = TcpStream::connect(reverse_in_addr).await.unwrap();
+    let (mut out_recv_conn, _) = out_listener.accept().await.unwrap();
+    reverse_in_conn.write_all(&forward_out_sent).await.unwrap();
+    reverse_in_conn.shutdown().await.unwrap();
     out_recv_conn.read_to_end(&mut received).await.unwrap();
 
     assert_eq!(received, message);


### PR DESCRIPTION
This PR adds synchronous compression handling to the tokio-based proxies. It also introduces a couple of integration tests to ensure that the proxying works as expected. In order to add the integration tests, I also refactored the project to include a lib.rs